### PR TITLE
Add index.html creation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,23 @@ Add run scripts to your `package.json`. The dev flag runs webpack-dev-server.
 }
 ```
 
-### 3. Create entry file
+### 3. Create entry/index files
+
+Create an `index.html` file.
+
+**Example:**
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="bundle.js"></script>
+  </body>
+</html>
+```
 
 Create an `entry.js` file.
 


### PR DESCRIPTION
When I first installed the package and followed the instructions in the README I didn’t realize I had to manually create an `index.html` file, so I was just starting at Node’s directory page for a minute. I’ve update the README with instructions for creating an `index.html` that links to the `bundle.js` script (see #1) and has a `<div>` for mounting the React app.
