### PR TITLE
Make example return elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ const div = document.getElementById('app')
 
 class App extends React.Component {
   render () {
-    <div>
-      <h1>Hotdamn!</h1>
-    </div>
+    return (
+      <div>
+        <h1>Hotdamn!</h1>
+      </div>
+    )
   }
 }
 


### PR DESCRIPTION
There’s a little issue in the README example `entry.js` file, which prevents React from properly mounting because the `<App />` component isn’t actually _returning_ elements. Small fix 😀 
